### PR TITLE
fix: use wildcard copy in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:20-alpine AS builder
 
 WORKDIR /app
-COPY package.json package-lock.json ./
-RUN npm ci
+COPY package*.json ./
+RUN npm ci || npm install
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
- Update `frontend/Dockerfile` to use `COPY package*.json ./` to robustly handle missing lockfiles in some contexts.
- Add fallback `npm ci || npm install` in Dockerfile.